### PR TITLE
Remove "Yesterday" in relative time

### DIFF
--- a/lib/relative.js
+++ b/lib/relative.js
@@ -13,11 +13,7 @@ module.exports = function(date) {
 	} else if(now.getMonth() > date.getMonth()) {
 		result = checkIsSingle(now.getMonth() - date.getMonth(), 'month');
 	} else if(now.getDate() > date.getDate()) {
-		if((now.getDate() - date.getDate()) === 1) {
-			result = 'Yesterday';
-		} else {
-			result = (now.getDate() - date.getDate()) + ' days';
-		}
+		result = (now.getDate() - date.getDate()) + ' days';
 	} else if(now.getHours() > date.getHours()) {
 		result = checkIsSingle(now.getHours() - date.getHours(), 'hour');
 	} else if(now.getMinutes() > date.getMinutes()) {

--- a/lib/relative.js
+++ b/lib/relative.js
@@ -13,7 +13,7 @@ module.exports = function(date) {
 	} else if(now.getMonth() > date.getMonth()) {
 		result = checkIsSingle(now.getMonth() - date.getMonth(), 'month');
 	} else if(now.getDate() > date.getDate()) {
-		result = (now.getDate() - date.getDate()) + ' days';
+		result = checkIsSingle(now.getDate() - date.getDate(), 'day');
 	} else if(now.getHours() > date.getHours()) {
 		result = checkIsSingle(now.getHours() - date.getHours(), 'hour');
 	} else if(now.getMinutes() > date.getMinutes()) {

--- a/test/relative.js
+++ b/test/relative.js
@@ -48,10 +48,10 @@ describe('Relative timing', function() {
 		assert.equal(relative(threeDays), '3 days');
 	});
 	
-	it('should return yesterday', function() {
+	it('should return one day', function() {
 		var threeDays = new Date();
 		threeDays.setDate(new Date().getDate() - 1);
-		assert.equal(relative(threeDays), 'Yesterday');
+		assert.equal(relative(threeDays), '1 day');
 	});
 	
 	it('should return three hours', function() {


### PR DESCRIPTION
The "Yesterday" value in relative time is illogical when compared to other possible values. Other values describe a length of time (2 days, 3 months etc.) whereas "yesterday" is an exact point in time. This PR fixes this issue by changing yesterday to "1 day".

Fixes #7 